### PR TITLE
Add ASCII argument to Base256Readable.String() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,21 @@ cipher = feistel.NewFPECipher(hash.SHA_256, "some-32-byte-long-key-to-be-safe", 
 obfuscated, err := cipher.Encrypt(source)
 
 str := obfuscated.String()
-assert.Equal(t, len(str), len(source))
+assert.Equal(t, len([]rune(str)), len(source)) // The source and the obfuscated result have the same number of characters
+
+ascii := obfuscated.String(true)
+assert.Equal(t, len(ascii), len(source)) // You must use the `true` argument to the String() method to be sure of that equality in Go (see below)
+
+assert.DeepEqual(t, len(obfuscated.Bytes()), len(source))
 ```
+
+As stated in the example above, the result of the cipher's `Encrypt()` method is a `Base256Readable` object.
+The `String()` method of the latter uses a special 256 charset (see [here](common/utils/base256/readable.go)) which may result in the use of characters that are more than one-byte encoded, thus resulting in an unequality in the results when simply using the `len()` function.
+But the underlying byte slice is of correct length, as well as the number of runes, ie. the number of characters to display.
+
+So, for example, you should always use the `Bytes()` method of the result to write bytes directly to your files, instead of the `String()` method which should only be used when displaying (to a screen, to stdout, ...) or use `String(true)` with the risk of having to print unreadable characters if the underlying bytes don't have values within the 33 to 126 range.
+
+Regarding the equality, keep in mind that this is due to the fact that the `len()` function in Go doesn't actually count the number of characters of a string but the length of its underlying byte slice. If the string uses characters that a multiple-byte encoded, then the `len()` function won't return the correct number of actual characters.
 
 
 ### Other implementations

--- a/common/utils/base256/readable.go
+++ b/common/utils/base256/readable.go
@@ -43,7 +43,14 @@ func (b256 Readable) NonEmpty() bool {
 }
 
 // String ...
-func (b256 Readable) String() string {
+//
+// NB: By passing `true` as argument, you signify you don't want to use the readable charset but force the ASCII rendering,
+// implying that you'd probably get unreadable characters if the underlying byte array uses byte that ranges over 127 but that
+// you'd get the correct length when using the len() function on the resulting string
+func (b256 Readable) String(useAscii ...bool) string {
+	if len(useAscii) == 1 && useAscii[0] {
+		return string(b256.Bytes())
+	}
 	return string(b256)
 }
 

--- a/common/utils/base256/readable_test.go
+++ b/common/utils/base256/readable_test.go
@@ -3,7 +3,9 @@ package base256_test
 import (
 	"testing"
 
+	"github.com/cyrildever/feistel"
 	"github.com/cyrildever/feistel/common/utils/base256"
+	"github.com/cyrildever/feistel/common/utils/hash"
 	utls "github.com/cyrildever/go-utls/common/utils"
 	"gotest.tools/assert"
 )
@@ -29,4 +31,22 @@ func TestBase256(t *testing.T) {
 	assert.DeepEqual(t, fpeB256.Bytes(), fpeBytes)
 	hex = "2a5d07024f5a501409"
 	assert.Equal(t, fpeB256.ToHex(), hex)
+
+	src := "my-source-data"
+	cipher := feistel.NewFPECipher(hash.SHA_256, "some-32-byte-long-key-to-be-safe", 128)
+	b256, err := cipher.Encrypt(src)
+	assert.NilError(t, err)
+	byteArr := []byte{62, 125, 126, 123, 99, 124, 118, 109, 108, 121, 97, 49, 33, 101}
+	assert.DeepEqual(t, b256.Bytes(), byteArr)
+	ascii := b256.String(true)
+	assert.Equal(t, ascii, ">}~{c|vmlya1!e")
+	assert.Equal(t, len(ascii), len(src))
+	notAscii := b256.String()
+	assert.Equal(t, notAscii, "`ÃÄÁ§Â¼²±¿¥RB©")
+	// Both results are visually 14 characters long, but the latter uses characters that range over 127, thus resulting in a longer underlying byte slice as computed by the len() function
+	assert.Assert(t, ascii != notAscii)
+	// But, as you can see, if you transform both strings in runes, than they are both equal - and of length 14 like the original source)
+	assert.Equal(t, len([]rune(ascii)), 14)
+	assert.Equal(t, len([]rune(notAscii)), 14)
+	assert.Equal(t, len(src), 14)
 }

--- a/fpe_test.go
+++ b/fpe_test.go
@@ -72,3 +72,16 @@ func TestFPEEncryptDecrypt(t *testing.T) {
 	}
 	assert.Equal(t, decrypted, ref)
 }
+
+func TestBase256String(t *testing.T) {
+	source := "my-source-data"
+	cipher := feistel.NewFPECipher(hash.SHA_256, "some-32-byte-long-key-to-be-safe", 128)
+
+	obfuscated, err := cipher.Encrypt(source)
+	assert.DeepEqual(t, obfuscated.Bytes(), []byte{62, 125, 126, 123, 99, 124, 118, 109, 108, 121, 97, 49, 33, 101})
+	assert.NilError(t, err)
+	str := obfuscated.String(true)
+	assert.Equal(t, str, ">}~{c|vmlya1!e") // Fully readable because, by some chance, the underlying byte slice has all bytes ranging from 33 to 126 (see above)
+	assert.Equal(t, len(source), len(str))
+	assert.DeepEqual(t, len(obfuscated.Bytes()), len(source)) // Always true
+}


### PR DESCRIPTION
Due to the way the `len()` function works in Go (not counting characters in a string but the length of the underlying byte slice), I've added a behavior to the `Base256Readable.String()` method to make sure if need be that the following assertion returns true:
```golang
source := "my-source-data"
cipher := feistel.NewFPECipher(hash.SHA_256, "some-32-byte-long-key-to-be-safe", 128)

obfuscated, _ := cipher.Encrypt(source)
str := obfuscated.String(true) // Notice the new optional argument set to true here
assert.Equal(t, len(source), len(str))
```

As it's not how I expect it to work by using the `Base256Readable` return type in the `Encrypt()`method of the FPE cipher, I didn't change the default behavior.

Read the new `README` for more information.