### PR TITLE
Add EncryptNumber method to FPECipher

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ I also created a special library for redacting classified documents using the ne
 
 ### Specific development
 
-I mainly use this library to manipulate text files, ie. strings. But, because the "Format" word in the FPE acronym could have different meanings, I've implemented an extra feature for the `FPECipher`: the possibility to preserve the visible format when the input is a number, ie. if you use a 9-digit number, you could get a 9-digit number from the `EncryptNumber()` method (see padding options and restriction for numbers lower than 256 below).
+I mainly use this library to manipulate text files, ie. strings. But, because the "Format" word in the FPE acronym could have different meanings, I've implemented an extra feature for the `FPECipher`: the possibility to preserve the _visible_ format when the input is a number, ie. if you use a 9-digit number, you could get a 9-digit number from the `EncryptNumber()` method (see padding options and restriction for numbers lower than `256` below).
 
 ```golang
 source := 123456789 // 9 digits

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ I also created a special library for redacting classified documents using the ne
 
 ### Specific development
 
-I mainly use this library to manipulate text files, ie. strings. But, because the "Format" word in the FPE acronym could have different meanings, I've implemented an extra feature for the `FPECipher`: the possibility to preserve the _visible_ format when the input is a number, ie. if you use a 9-digit number, you could get a 9-digit number from the `EncryptNumber()` method (see padding options and restriction for numbers lower than `256` below).
+I mainly use this library to manipulate text files, ie. strings. But, because the "Format" word in the FPE acronym could have different meanings, I've implemented an extra feature for the `FPECipher`: the possibility to preserve the _visible_ format when the input is a number, ie. if you use a 9-digit number, you could get a 9-digit number from the `EncryptNumber()` method (see below for padding options and restrictions to numbers lower than `256`).
 
 ```golang
 source := 123456789 // 9 digits

--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ _NB: You might want to use the [`NumberToReadable()`](common/utils/base256/reada
 
 **IMPORTANT:** Due to the way the Feistel cipher operates, numbers below 256 (ie. only one-byte long) can't preserve the length when using the `EncryptNumber()` method. If length matters, consider using `EncryptString()` instead.
 
+Should you want to use a number with value higher than the accepted max `uint64` value by Golang (`18446744073709551615`) or a floating number, you probably want to use splitting strategies. For example, split it in two numbers that respect the maximum boundaries of a large integer or use both parts (integer and decimal) of the float but not the decimal point itself and rebuild the number afterwards.
+
 
 ### White papers
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ For those interested, I also made two other implementations of these ciphers:
 I also created a special library for redacting classified documents using the new FPE cipher. Feel free to [contact me](mailto:cdever@edgewhere.fr) about it.
 
 
-### Specific development in Golang
+### Specific development
 
 I mainly use this library to manipulate text files, ie. strings. But, because the "Format" word in the FPE acronym could have different meanings, I've implemented an extra feature for the `FPECipher`: the possibility to preserve the visible format when the input is a number, ie. if you use a 9-digit number, you could get a 9-digit number from the `EncryptNumber()` method (see padding options and restriction for numbers lower than 256 below).
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ So, for example, you should always use the `Bytes()` method of the result to wri
 
 Regarding the equality, keep in mind that this is due to the fact that the `len()` function in Go doesn't actually count the number of characters of a string but the length of its underlying byte slice. If the string uses characters that is multiple-byte encoded, then the `len()` function won't return the correct number of actual characters.
 
+**IMPORTANT:** Due to the way the Feistel cipher operates, a word formed of a single character encoded on a single-byte (like `a` for example) is not modified when using the `Encrypt()` or `EncryptString()` methods.
+
 
 ### Other implementations
 
@@ -106,9 +108,9 @@ For those interested, I also made two other implementations of these ciphers:
 I also created a special library for redacting classified documents using the new FPE cipher. Feel free to [contact me](mailto:cdever@edgewhere.fr) about it.
 
 
-### Specific development
+### Specific development in Golang
 
-I mainly use this library to manipulate text files, ie. strings. But, because the "Format" word in the FPE acronym could have different meanings, I've implemented an extra feature for the `FPECipher`: the possibility to preserve the visible format when the input is a number, ie. if you use a 9-digit number, you could get a 9-digit number from the `EncryptNumber()` method.
+I mainly use this library to manipulate text files, ie. strings. But, because the "Format" word in the FPE acronym could have different meanings, I've implemented an extra feature for the `FPECipher`: the possibility to preserve the visible format when the input is a number, ie. if you use a 9-digit number, you could get a 9-digit number from the `EncryptNumber()` method (see padding options and restriction for numbers lower than 256 below).
 
 ```golang
 source := 123456789 // 9 digits
@@ -128,7 +130,9 @@ As you can see, it means that the returned `Readable` type embeds two new method
 - The `Uint64()` method which returns the integer value (the eventual sign is left to its own devices);
 - The `ToNumber()` method which returns its stringified version, eventually zero-padded to match the minimum length passed as argument (this could be useful to preserve for sure the number of digits to print, as the encryption through the Feistel cipher may result in a smaller number than the original).
 
-**IMPORTANT:** Due to the way the Feistel cipher operates, numbers below 256 can't preserve the length when using the `EncryptNumber()` method. If length matters, use `EncryptString()` instead. 
+_NB: You might want to use the [`NumberToReadable()`](common/utils/base256/readable.go) function when using the ciphered number for decryption._
+
+**IMPORTANT:** Due to the way the Feistel cipher operates, numbers below 256 (ie. only one-byte long) can't preserve the length when using the `EncryptNumber()` method. If length matters, consider using `EncryptString()` instead.
 
 
 ### White papers

--- a/common/utils/base256/readable.go
+++ b/common/utils/base256/readable.go
@@ -3,6 +3,7 @@ package base256
 import (
 	"encoding/binary"
 	"fmt"
+	"math/bits"
 
 	utls "github.com/cyrildever/go-utls/common/utils"
 )
@@ -116,6 +117,15 @@ func HexToReadable(hex string) (b256 Readable, err error) {
 	if err != nil {
 		return
 	}
+	b256 = ToBase256Readable(bytes)
+	return
+}
+
+// NumberToReadable ...
+func NumberToReadable(n uint64) (b256 Readable, err error) {
+	buf := make([]byte, 8)
+	binary.BigEndian.PutUint64(buf, n)
+	bytes := buf[bits.LeadingZeros64(n)>>3:]
 	b256 = ToBase256Readable(bytes)
 	return
 }

--- a/common/utils/base256/readable.go
+++ b/common/utils/base256/readable.go
@@ -77,10 +77,9 @@ func (b256 Readable) ToNumber(nbZeroPad ...int) string {
 
 // Uint64 ...
 func (b256 Readable) Uint64() uint64 {
-	length := int(8 * (float64(len(b256.Bytes())/8) + 1))
-	buf := make([]byte, length)
+	buf := make([]byte, 8)
 	for i, b := range b256.Bytes() {
-		buf[i+length-len(b256.Bytes())] = b
+		buf[i+8-b256.Len()] = b
 	}
 	return binary.BigEndian.Uint64(buf)
 }

--- a/common/utils/base256/readable.go
+++ b/common/utils/base256/readable.go
@@ -1,6 +1,9 @@
 package base256
 
 import (
+	"encoding/binary"
+	"fmt"
+
 	utls "github.com/cyrildever/go-utls/common/utils"
 )
 
@@ -57,6 +60,28 @@ func (b256 Readable) String(useAscii ...bool) string {
 // ToHex ...
 func (b256 Readable) ToHex() string {
 	return utls.ToHex(b256.Bytes())
+}
+
+// ToNumber returns the stringified value of the underlying integer
+//
+// You may pass a minimum size for the returned number to add padding zeroes accordingly
+func (b256 Readable) ToNumber(nbZeroPad ...int) string {
+	var length int
+	if len(nbZeroPad) > 0 {
+		length = nbZeroPad[0]
+	}
+	format := "%" + fmt.Sprintf("0%dd", length)
+	return fmt.Sprintf(format, b256.Uint64())
+}
+
+// Uint64 ...
+func (b256 Readable) Uint64() uint64 {
+	length := int(8 * (float64(len(b256.Bytes())/8) + 1))
+	buf := make([]byte, length)
+	for i, b := range b256.Bytes() {
+		buf[i+length-len(b256.Bytes())] = b
+	}
+	return binary.BigEndian.Uint64(buf)
 }
 
 //--- FUNCTION

--- a/exception/errors.go
+++ b/exception/errors.go
@@ -1,5 +1,37 @@
 package exception
 
+// NotUint64Error ...
+type NotUint64Error struct {
+	message string
+}
+
+func (e *NotUint64Error) Error() string {
+	return e.message
+}
+
+// NewNotUint64Error ...
+func NewNotUint64Error() *NotUint64Error {
+	return &NotUint64Error{
+		message: "probably not a uint64 byte array",
+	}
+}
+
+// TooSmallToPreserveLengthError ...
+type TooSmallToPreserveLengthError struct {
+	message string
+}
+
+func (e *TooSmallToPreserveLengthError) Error() string {
+	return e.message
+}
+
+// NewTooSmallToPreserveLengthError ...
+func NewTooSmallToPreserveLengthError() *TooSmallToPreserveLengthError {
+	return &TooSmallToPreserveLengthError{
+		message: "too small to preserve length",
+	}
+}
+
 // UnkownEngineError ...
 type UnkownEngineError struct {
 	message string

--- a/fpe.go
+++ b/fpe.go
@@ -2,6 +2,7 @@ package feistel
 
 import (
 	"encoding/binary"
+	"fmt"
 	"math/bits"
 
 	"github.com/cyrildever/feistel/common/utils"
@@ -76,6 +77,20 @@ func (f FPECipher) EncryptNumber(src uint64) (ciphered base256.Readable, err err
 		err = exception.NewWrongCipherParametersError()
 		return
 	}
+
+	if src < 256 {
+		bytes := make([]byte, 1)
+		bytes = append(bytes, encodeInt(src)...)
+		res, e := f.Encrypt(string(bytes))
+		if e != nil {
+			err = e
+			return
+		}
+		ciphered = res
+		err = fmt.Errorf("too small to respect length")
+		return
+	}
+
 	bytes := encodeInt(src)
 	str := string(bytes)
 

--- a/fpe_test.go
+++ b/fpe_test.go
@@ -126,4 +126,10 @@ func TestReadableNumber(t *testing.T) {
 	deobfuscated, err = cipher.DecryptNumber(obfuscated)
 	assert.NilError(t, err)
 	assert.Equal(t, deobfuscated, source)
+
+	source = uint64(18446744073709551615) // max accepted uint64 value
+	obfuscated, err = cipher.EncryptNumber(source)
+	assert.NilError(t, err)
+	assert.Equal(t, obfuscated.Uint64(), uint64(17630367666640955566))
+	assert.Equal(t, obfuscated.ToNumber(), "17630367666640955566")
 }

--- a/fpe_test.go
+++ b/fpe_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/cyrildever/feistel"
 	"github.com/cyrildever/feistel/common/utils/base256"
 	"github.com/cyrildever/feistel/common/utils/hash"
+	"github.com/cyrildever/feistel/exception"
 	utls "github.com/cyrildever/go-utls/common/utils"
 	"gotest.tools/assert"
 )
@@ -115,7 +116,9 @@ func TestReadableNumber(t *testing.T) {
 	source = uint64(123)
 
 	obfuscated, err = cipher.EncryptNumber(source)
-	assert.Error(t, err, "too small to respect length") // Hence the error
+	assert.Error(t, err, "too small to preserve length") // Hence the error
+	_, ok := err.(*exception.TooSmallToPreserveLengthError)
+	assert.Assert(t, ok)
 	assert.Equal(t, obfuscated.Uint64(), uint64(24359))
 	assert.Equal(t, obfuscated.ToNumber(), "24359")
 

--- a/fpe_test.go
+++ b/fpe_test.go
@@ -110,4 +110,17 @@ func TestReadableNumber(t *testing.T) {
 	deobfuscated, err := cipher.DecryptNumber(obfuscated)
 	assert.NilError(t, err)
 	assert.Equal(t, deobfuscated, source)
+
+	// Numbers below 256 don't respect length during encryption
+	source = uint64(123)
+
+	obfuscated, err = cipher.EncryptNumber(source)
+	assert.Error(t, err, "too small to respect length") // Hence the error
+	assert.Equal(t, obfuscated.Uint64(), uint64(24359))
+	assert.Equal(t, obfuscated.ToNumber(), "24359")
+
+	obfuscated, _ = base256.NumberToReadable(24359)
+	deobfuscated, err = cipher.DecryptNumber(obfuscated)
+	assert.NilError(t, err)
+	assert.Equal(t, deobfuscated, source)
 }

--- a/fpe_test.go
+++ b/fpe_test.go
@@ -111,7 +111,7 @@ func TestReadableNumber(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Equal(t, deobfuscated, source)
 
-	// Numbers below 256 don't respect length during encryption
+	// Numbers below 256 don't preserve length during encryption
 	source = uint64(123)
 
 	obfuscated, err = cipher.EncryptNumber(source)

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,6 @@ go 1.14
 require (
 	github.com/cyrildever/go-utls v1.9.0
 	github.com/ethereum/go-ethereum v1.10.25
-	golang.org/x/crypto v0.0.0-20220926161630-eccd6366d1be
+	golang.org/x/crypto v0.0.0-20221010152910-d6f0a8c073c2
 	gotest.tools v2.2.0+incompatible
 )

--- a/go.sum
+++ b/go.sum
@@ -427,6 +427,8 @@ golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0
 golang.org/x/crypto v0.0.0-20220924013350-4ba4fb4dd9e7/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20220926161630-eccd6366d1be h1:fmw3UbQh+nxngCAHrDCCztao/kbYFnWjoqop8dHx05A=
 golang.org/x/crypto v0.0.0-20220926161630-eccd6366d1be/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/crypto v0.0.0-20221010152910-d6f0a8c073c2 h1:x8vtB3zMecnlqZIwJNUUpwYKYSqCz5jXbiyv0ZJJZeI=
+golang.org/x/crypto v0.0.0-20221010152910-d6f0a8c073c2/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20180321215751-8460e604b9de/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20180807140117-3d87b88a115f/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=


### PR DESCRIPTION
As stated in the introduction to my second white paper, I mainly use this library to manipulate text files, ie. strings. But, because the "Format" word in the FPE acronym could have different meanings, this PR implements an extra feature for the `FPECipher`: the possibility to preserve the visible format when the input is a number.

Be aware that it's not making this library a full-purpose FPE cipher but it's getting closer.