### PR TITLE
Optimize string handling, add a benchmark

### DIFF
--- a/common/utils/base256/readable.go
+++ b/common/utils/base256/readable.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math/bits"
+	"strings"
 
 	utls "github.com/cyrildever/go-utls/common/utils"
 )
@@ -103,11 +104,11 @@ func IndexOf(char rune) int {
 
 // ToBase256Readable ...
 func ToBase256Readable(barray []byte) Readable {
-	str := ""
+	var str strings.Builder
 	for _, b := range barray {
-		str += CharAt(int(b))
+		str.WriteRune(rune(CHARSET[b]))
 	}
-	return Readable(str)
+	return Readable(str.String())
 }
 
 // HexToReadable ...

--- a/common/utils/strings.go
+++ b/common/utils/strings.go
@@ -10,11 +10,11 @@ func Add(str1, str2 string) (string, error) {
 	if len(str1) != len(str2) {
 		return "", errors.New("to be added, items must be of the same length")
 	}
-	added := ""
+	var added strings.Builder
 	for i := 0; i < len(str1); i++ {
-		added += string(str1[i] + str2[i])
+		added.WriteRune(rune(str1[i] + str2[i]))
 	}
-	return added, nil
+	return added.String(), nil
 }
 
 // Extract returns an extraction of the passed string of the desired length from the passed start index.

--- a/fpe_test.go
+++ b/fpe_test.go
@@ -155,3 +155,18 @@ func TestReadableNumber(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Equal(t, deobfuscated, uint64(0))
 }
+
+func BenchmarkEncrypt(b *testing.B) {
+	cipher := feistel.NewFPECipher(hash.SHA_256, "8ed9dcc1701c064f0fd7ae235f15143f989920e0ee9658bb7882c8d7d5f05692", 10)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.StartTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, err := cipher.Encrypt("Edgewhere")
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
The OpenTelemetry Arrow [project](https://github.com/open-telemetry/otel-arrow) has an obfuscating processor based on this package. While running a large data set through the processor, I noticed several points where the process ground to a near halt, busy in garbage collection. I pinpointed two locations where a small fix would help, and indeed this has helped unblock a process that had become very slow due to memory pressure.

BEFORE
```
goos: darwin
goarch: arm64
pkg: github.com/cyrildever/feistel
BenchmarkEncrypt-10    	  286191	      4094 ns/op	    2880 B/op	     197 allocs/op
```

AFTER
```
BenchmarkEncrypt-10    	  403876	      2881 ns/op	    2400 B/op	     106 allocs/op
```
